### PR TITLE
Species gene name updated in RGP and EWAS'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline{
 						stage("Main: Infer ${species}"){
 							script{
 								withCredentials([file(credentialsId: 'Config', variable: 'ConfigFile')]){
-									sh "java -Xmx${env.JAVA_MEM_MAX}m -jar target/orthoinference-${env.ORTHOINFERENCE_VERSION}-jar-with-dependencies.jar $ConfigFile ${species}"
+									sh "java -Xmx${env.JAVA_MEM_MAX}m -jar target/orthoinference-*-jar-with-dependencies.jar $ConfigFile ${species}"
 								}
 							}
 						}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,12 +23,10 @@ pipeline{
 		stage('Setup: Backup release_current'){
 			steps{
 				script{
-					dir('orthoinference'){
-						withCredentials([usernamePassword(credentialsId: 'mySQLUsernamePassword', passwordVariable: 'pass', usernameVariable: 'user')]){
-							def release_current_before_orthoinference_dump = "${env.RELEASE_CURRENT}_${currentRelease}_before_orthoinference.dump"
-							sh "mysqldump -u$user -p$pass ${env.RELEASE_CURRENT} > $release_current_before_orthoinference_dump"
-							sh "gzip -f $release_current_before_orthoinference_dump"
-						}
+					withCredentials([usernamePassword(credentialsId: 'mySQLUsernamePassword', passwordVariable: 'pass', usernameVariable: 'user')]){
+						def release_current_before_orthoinference_dump = "${env.RELEASE_CURRENT}_${currentRelease}_before_orthoinference.dump"
+						sh "mysqldump -u$user -p$pass ${env.RELEASE_CURRENT} > $release_current_before_orthoinference_dump"
+						sh "gzip -f $release_current_before_orthoinference_dump"
 					}
 				}
 			}
@@ -39,9 +37,7 @@ pipeline{
 		stage('Setup: Build jar file'){
 			steps{
 				script{
-					dir('orthoinference'){
-						sh "mvn clean compile assembly:single"
-					}
+					sh "mvn clean compile assembly:single"
 				}
 				// This script block executes the main orthoinference code one species at a time.
 				// It takes all Human Reaction instances in the database and attempts to project each Reaction to each species by
@@ -52,10 +48,8 @@ pipeline{
 					for (species in speciesList) {
 						stage("Main: Infer ${species}"){
 							script{
-								dir('orthoinference'){
-									withCredentials([file(credentialsId: 'Config', variable: 'ConfigFile')]){
-										sh "java -Xmx${env.JAVA_MEM_MAX}m -jar target/orthoinference-${env.ORTHOINFERENCE_VERSION}-jar-with-dependencies.jar $ConfigFile ${species}"
-									}
+								withCredentials([file(credentialsId: 'Config', variable: 'ConfigFile')]){
+									sh "java -Xmx${env.JAVA_MEM_MAX}m -jar target/orthoinference-${env.ORTHOINFERENCE_VERSION}-jar-with-dependencies.jar $ConfigFile ${species}"
 								}
 							}
 						}
@@ -67,12 +61,10 @@ pipeline{
 		stage('Post: Backup DB'){
 			steps{
 				script{
-					dir('orthoinference'){
-						withCredentials([usernamePassword(credentialsId: 'mySQLUsernamePassword', passwordVariable: 'pass', usernameVariable: 'user')]){
-							def release_current_after_orthoinference_dump = "${env.RELEASE_CURRENT}_${currentRelease}_after_orthoinference.dump"
-							sh "mysqldump -u$user -p$pass ${env.RELEASE_CURRENT} > $release_current_after_orthoinference_dump"
-							sh "gzip -f $release_current_after_orthoinference_dump"
-						}
+					withCredentials([usernamePassword(credentialsId: 'mySQLUsernamePassword', passwordVariable: 'pass', usernameVariable: 'user')]){
+						def release_current_after_orthoinference_dump = "${env.RELEASE_CURRENT}_${currentRelease}_after_orthoinference.dump"
+						sh "mysqldump -u$user -p$pass ${env.RELEASE_CURRENT} > $release_current_after_orthoinference_dump"
+						sh "gzip -f $release_current_after_orthoinference_dump"
 					}
 				}
 			}
@@ -81,15 +73,13 @@ pipeline{
 		stage('Archive logs and backups'){
 			steps{
 				script{
-					dir('orthoinference'){
-						sh "mkdir -p archive/${currentRelease}/logs"
-						sh "mv --backup=numbered *_${currentRelease}_*.dump.gz archive/${currentRelease}/"
-						sh "gzip logs/*"
-						sh "mv logs/* archive/${currentRelease}/logs/"
-						sh "mkdir -p ${currentRelease}"
-						sh "gzip -f *.txt"
-						sh "mv *.txt.gz ${currentRelease}/"
-					}
+					sh "mkdir -p archive/${currentRelease}/logs"
+					sh "mv --backup=numbered *_${currentRelease}_*.dump.gz archive/${currentRelease}/"
+					sh "gzip logs/*"
+					sh "mv logs/* archive/${currentRelease}/logs/"
+					sh "mkdir -p ${currentRelease}"
+					sh "gzip -f *.txt"
+					sh "mv *.txt.gz ${currentRelease}/"
 				}
 			}
 		}

--- a/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -120,6 +120,7 @@ public class EventsInferrer
 			readAndSetGeneNameMappingFile(species, pathToOrthopairs);
 		} catch (Exception e) {
 			logger.fatal("Unable to locate " + speciesName +" mapping file: hsap_" + species + "_mapping.tsv. Orthology prediction not possible.");
+			e.printStackTrace();
 			return;
 		}
 		EWASInferrer.readENSGMappingFile(species, pathToOrthopairs);
@@ -218,7 +219,7 @@ public class EventsInferrer
 	/**
 	 * Read in the {species}_gene_name_mapping.tsv file and create a Map of UniProt identifiers to gene names.
 	 * @param species String - 4-letter shortened version of species name (eg: Homo sapiens --> hsap).
-	 * @param pathToOrthopairs
+	 * @param pathToOrthopairs String - Path to directory containing orthopairs files.
 	 * @return pathToOrthopairs String - Path to directory containing orthopairs files.
 	 * @throws IOException - Thrown if file is not found.
 	 */
@@ -297,8 +298,8 @@ public class EventsInferrer
 
 	}
 
-	private static void readAndSetHomologueMappingFile(String species, String hsap, String pathToOrthopairs) throws IOException {
-		Map<String,String[]> homologueMappings = readHomologueMappingFile(species, "hsap", pathToOrthopairs);
+	private static void readAndSetHomologueMappingFile(String species, String fromSpecies, String pathToOrthopairs) throws IOException {
+		Map<String,String[]> homologueMappings = readHomologueMappingFile(species, fromSpecies, pathToOrthopairs);
 		ProteinCountUtility.setHomologueMappingFile(homologueMappings);
 		EWASInferrer.setHomologueMappingFile(homologueMappings);
 	}


### PR DESCRIPTION
Second part of the species gene name changes. This takes the gene name mapping file that is newly generated in OrthoPairs, creates a Map and then adds them to inferred RGPs and EWAS'. On a recommendation from Guanming, for the EWAS instances receiving the gene name, the new name takes precedence over the other names (original Human gene name, UniProt accession ID) and a new display name is generated that matches the species gene name. 