### PR TITLE
Feature/automated skiplist

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,13 @@ Orthoinference can be run once the <a href="https://github.com/reactome/release-
   personId=reactomePersonInstanceId
   ```
   
-  <h4> Setting normal_event_skip_list.txt </h4>
+  <h4> Orthoinference skiplists </h4>
   
-Typically there are a number of instances that inference will be skipped for. The `normal_event_skip_list.txt` file denotes these instances, listed by Reactome IDs in the format shown below:
+  Historically, the list of ReactionlikeEvents that are skipped during Orthoinference have been manually created by a Curator. As of August 2020, this process has been automated in two ways: 1) A static skiplist that is hard-coded into the orthoinference code and 2) through automated enforcement based on the membership of the ReactionlikeEvent in the Disease TopLevelPathway.
   
-  ```
-  1234567
-  8910987
-  6543210
-  ```
-  If there aren't any instances that are to be skipped, the empty file still needs to exist.
+ The static skiplist currently consists of the HIV Infection (<b>162906</b>), Influenza Infection (DbId: <b>168255</b>) and Amyloid Fiber Formation (<b>977225</b>; only non-Disease skiplist instance) Pathways. Orthoinference creates a skiplist of all ReactionlikeEvents contained within these Pathways.
+  
+  The automated skiplist is only focused on skipping inference for instances that are children of the Disease TopLevelPathway. If a ReactionlikeEvent only exists as a child of the Disease pathway, than inference will be skipped. In cases where a ReactionlikeEvent is a member of the Disease AND another TopLevelPathway, then <b>Reaction</b> inference proceeds as normal. During <b>Pathway</b> inference, the inference of the non-Disease pathways are allowed while the Disease Pathway inference (and its children) are suppressed for the instance. 
   
   <h3> Running Orthoinference </h3>
   

--- a/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -137,7 +137,6 @@ public class EventsInferrer
 		createAndSetSpeciesInstance(speciesName);
 		setSummationInstance();
 		setEvidenceTypeInstance();
-		PathwaysInferrer.setDiseaseInstance(dbAdaptor.fetchInstance(InstanceUtilities.getDiseasePathwayDbId()));
 		OrthologousEntityGenerator.setComplexSummationInstance();
 
 /**

--- a/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -84,7 +84,8 @@ public class EventsInferrer
 			logger.fatal("Unable to locate skiplist file: " + pathToSkipList);
 			System.exit(1);
 		}
-		SkipInstanceChecker.getSkipList(pathToSkipList);
+		// Finds all skippable ReactionlikeEvents based on a static list of skippable Pathways.
+		SkipInstanceChecker.buildStaticSkipList();
 
 		JSONParser parser = new JSONParser();
 		Object obj = parser.parse(new FileReader(pathToSpeciesConfig));
@@ -136,6 +137,7 @@ public class EventsInferrer
 		createAndSetSpeciesInstance(speciesName);
 		setSummationInstance();
 		setEvidenceTypeInstance();
+		PathwaysInferrer.setDiseaseInstance(dbAdaptor.fetchInstance(InstanceUtilities.getDiseasePathwayDbId()));
 		OrthologousEntityGenerator.setComplexSummationInstance();
 
 /**

--- a/src/main/java/org/reactome/orthoinference/InstanceUtilities.java
+++ b/src/main/java/org/reactome/orthoinference/InstanceUtilities.java
@@ -1,20 +1,17 @@
 package org.reactome.orthoinference;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.gk.model.GKInstance;
 import static org.gk.model.ReactomeJavaConstants.*;
+import static org.reactome.util.general.CollectionUtils.safeList;
+
 import org.gk.persistence.MySQLAdaptor;
 import org.gk.schema.GKSchemaAttribute;
 import org.gk.schema.GKSchemaClass;
 import org.gk.schema.SchemaClass;
-
 
 // GenerateInstance is meant to act as a catch-all for functions that are instance-oriented, such as creating, mocking, or identical-checking.
 public class InstanceUtilities {
@@ -24,7 +21,7 @@ public class InstanceUtilities {
 	private static GKInstance speciesInst;
 	private static GKInstance instanceEditInst;
 	private static Map<String,GKInstance> mockedIdenticals = new HashMap<>();
-	private static final long DISEASE_PATHWAY_DBID = 1643685L;
+	private static final long DISEASE_PATHWAY_DB_ID = 1643685L;
 	
 	// Creates new instance that will be inferred based on the incoming instances class		
 	public static GKInstance createNewInferredGKInstance(GKInstance instanceToBeInferred) throws Exception
@@ -207,7 +204,7 @@ public class InstanceUtilities {
 	}
 
 	/**
-	 * This method returns true if the only parent Pathway of the incoming Event instane is Disease.
+	 * This method returns true if the only parent Pathway of the incoming Event instance is Disease.
 	 * Instances with only Disease as a parent will not be inferred. Those that are a member of Disease AND
 	 * another Pathway will be inferred, but the Disease Pathway (and sub-Pathway) inference will be skipped.
 	 * @param eventInst -- GKInstance that will be checked for parent Pathways.
@@ -215,47 +212,29 @@ public class InstanceUtilities {
 	 * @throws Exception -- Thrown by MySQLAdaptor.
 	 */
 	public static boolean onlyInDiseasePathway(GKInstance eventInst) throws Exception {
-		Set<Long> topLevelPathwayDbIds = getTopLevelParents(eventInst);
-		return topLevelPathwayDbIds.size() == 1 && topLevelPathwayDbIds.contains(DISEASE_PATHWAY_DBID);
-	}
-
-	/**
-	 * Helper method for 'onlyInDiseasePathway'. Finds DbIds of all TopLevelPathways of instance.
-	 * @param eventInst -- GKInstance for which all TopLevelPathway DbIds will be found.
-	 * @return -- Set<GKInstance> containing a list of all TopLevelPathway DbIds for incoming Event instance.
-	 * @throws Exception -- Thrown by MySQLAdaptor.
-	 */
-	private static Set<Long> getTopLevelParents(GKInstance eventInst) throws Exception {
-		Set<Long> topLevelPathwayDbIds = new HashSet<>();
-		if (eventInst.getReferers(hasEvent) != null) {
-			for (GKInstance pathwayInst : (Collection<GKInstance>) eventInst.getReferers(hasEvent)) {
-				topLevelPathwayDbIds.addAll(getPathwayReferrals(pathwayInst));
-			}
-		}
-		return topLevelPathwayDbIds;
+		Set<Long> topLevelPathwayDbIds = getTopLevelPathwayDbIds(eventInst);
+		return topLevelPathwayDbIds.size() == 1 && topLevelPathwayDbIds.contains(DISEASE_PATHWAY_DB_ID);
 	}
 
 	/**
 	 * Finds all 'hasEvent' referrals for the incoming Pathway instance. If there aren't any referrals via that attribute,
 	 * then it is considered a TopLevelPathway. TopLevelPathway DbIds are added to a Set and returned. This method
 	 * checks all Pathway referrals recursively up the Pathway hierarchy.
-	 * @param pathwayInst -- GKInstance that will be checked for 'hasEvent' referrals.
+	 * @param pathway -- GKInstance that will be checked for 'hasEvent' referrals.
 	 * @return -- Set<GKInstance> containing a list of all TopLevelPathway DbIds for incoming Event instance.
 	 * @throws Exception -- Thrown by MySQLAdaptor.
 	 */
-	private static Set<Long> getPathwayReferrals(GKInstance pathwayInst) throws Exception {
-		Set<Long> topLevelPathwayDbIds = new HashSet<>();
-		if (pathwayInst.getReferers(hasEvent) != null) {
-			for (GKInstance parentPathwayInst : (Collection<GKInstance>) pathwayInst.getReferers(hasEvent)) {
-				if (parentPathwayInst.getReferers(hasEvent) == null || parentPathwayInst.getReferers(hasEvent).size() == 0) {
-					topLevelPathwayDbIds.add(parentPathwayInst.getDBID());
-				} else {
-					topLevelPathwayDbIds.addAll(getPathwayReferrals(parentPathwayInst));
-				}
-			}
-		} else {
-			topLevelPathwayDbIds.add(pathwayInst.getDBID());
+	private static Set<Long> getTopLevelPathwayDbIds(GKInstance pathway) throws Exception {
+		List<GKInstance> parentPathways = safeList(pathway.getReferers(hasEvent));
+		if (parentPathways.isEmpty()) {
+			return new HashSet<>(Arrays.asList(pathway.getDBID()));
 		}
+
+		Set<Long> topLevelPathwayDbIds = new HashSet<>();
+		for (GKInstance parentPathway : parentPathways) {
+			topLevelPathwayDbIds.addAll(getTopLevelPathwayDbIds(parentPathway));
+		}
+
 		return topLevelPathwayDbIds;
 	}
 	
@@ -275,6 +254,6 @@ public class InstanceUtilities {
 	}
 
 	public static long getDiseasePathwayDbId() {
-		return DISEASE_PATHWAY_DBID;
+		return DISEASE_PATHWAY_DB_ID;
 	}
 }

--- a/src/main/java/org/reactome/orthoinference/PathwaysInferrer.java
+++ b/src/main/java/org/reactome/orthoinference/PathwaysInferrer.java
@@ -18,6 +18,7 @@ public class PathwaysInferrer {
 	private static GKInstance instanceEditInst;
 	private static List<GKInstance> updatedInferrableHumanEvents = new ArrayList<>();
 	private static Map<GKInstance, GKInstance> inferredEventIdenticals = new HashMap<>();
+	private static GKInstance diseasePathwayInst;
 
 	// This class populates species pathways with the instances that have been inferred. This was copied heavily from the Perl, so my explanations are a little sparse here.
 	public static void inferPathways(List<GKInstance> inferrableHumanEvents) throws Exception
@@ -73,8 +74,15 @@ public class PathwaysInferrer {
 
 		for (GKInstance sourcePathwayReferralInst : sourcePathwayReferralInstances)
 		{
+			// Disease TopLevelPathway inference is skipped.
+			if (sourcePathwayReferralInst.equals(diseasePathwayInst)) {
+				logger.info("Pathway referral is " + diseasePathwayInst + " -- skipping Pathway inference");
+				return;
+			}
+
 			logger.info("Generating inferred Pathway: " + sourcePathwayReferralInst);
-			if (inferredEventIdenticals.get(sourcePathwayReferralInst) == null)
+			// Pathways that have been inferred already are skipped, as are Pathways that are only children of the Disease TopLevelPathway.
+			if (inferredEventIdenticals.get(sourcePathwayReferralInst) == null && !InstanceUtilities.onlyInDiseasePathway(sourcePathwayReferralInst))
 			{
 				inferPathway(sourcePathwayReferralInst);
 			} else {
@@ -268,5 +276,9 @@ public class PathwaysInferrer {
 	public static void setInferredEvent(Map<GKInstance,GKInstance> inferredEventCopy)
 	{
 		inferredEventIdenticals = inferredEventCopy;
+	}
+
+	public static void setDiseaseInstance(GKInstance disease) {
+		diseasePathwayInst = disease;
 	}
 }

--- a/src/main/java/org/reactome/orthoinference/SkipInstanceChecker.java
+++ b/src/main/java/org/reactome/orthoinference/SkipInstanceChecker.java
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.gk.model.ClassAttributeFollowingInstruction;
 import org.gk.model.GKInstance;
-import org.gk.model.InstanceUtilities;
+import static org.gk.model.InstanceUtilities.followInstanceAttributes;
 import static org.gk.model.ReactomeJavaConstants.*;
 
 import org.gk.persistence.MySQLAdaptor;
@@ -16,17 +16,17 @@ public class SkipInstanceChecker {
 	private static final Logger logger = LogManager.getLogger();
 	private static MySQLAdaptor dba;
 	private static Set<String> skipList = new HashSet<>();
-	private static final long HIV_INFECTION_DBID = 162906L;
-	private static final long INFLUENZA_INFECTION_DBID = 168255L;
-	private static final long AMYLOID_FIBER_FORMATION_DBID = 977225L;
+	private static final long HIV_INFECTION_DB_ID = 162906L;
+	private static final long INFLUENZA_INFECTION_DB_ID = 168255L;
+	private static final long AMYLOID_FIBER_FORMATION_DB_ID = 977225L;
 
 	// Skiplist was traditionally provided in a file, but since it's currently just 3 instances, I've just hard-coded them here.
 	public static void buildStaticSkipList() throws Exception
 	{
 		List<Long> pathwayIdsToSkip = Arrays.asList(
-			HIV_INFECTION_DBID,
-			INFLUENZA_INFECTION_DBID,
-			AMYLOID_FIBER_FORMATION_DBID
+			HIV_INFECTION_DB_ID,
+			INFLUENZA_INFECTION_DB_ID,
+			AMYLOID_FIBER_FORMATION_DB_ID
 		);
 		for (long pathwayId : pathwayIdsToSkip)
 		{
@@ -38,7 +38,7 @@ public class SkipInstanceChecker {
 				classesToFollow.add(new ClassAttributeFollowingInstruction(Pathway, new String[]{hasEvent}, new String[]{}));
 				String[] outClasses = new String[] {ReactionlikeEvent};
 				@SuppressWarnings("unchecked")
-				Collection<GKInstance> followedInstances = InstanceUtilities.followInstanceAttributes(pathwayInst, classesToFollow, outClasses);
+				Collection<GKInstance> followedInstances = followInstanceAttributes(pathwayInst, classesToFollow, outClasses);
 
 				for (GKInstance entityInst : followedInstances)
 				{
@@ -60,7 +60,7 @@ public class SkipInstanceChecker {
 
 		// If the only TopLevelPathway of a Reaction is 'Disease', then it is skipped.
 		// Otherwise, it is inferred, making sure in cases where a Reaction is also a part of 'Disease' that that Pathway is not inferred.
-		if (org.reactome.orthoinference.InstanceUtilities.onlyInDiseasePathway(reactionInst)) {
+		if (InstanceUtilities.onlyInDiseasePathway(reactionInst)) {
 			logger.info(reactionInst + " has only Disease TopLevelPathway -- skipping");
 			return true;
 		}


### PR DESCRIPTION
This removes the dependency on a static skiplist file from Orthoinference. As the README describes, skipping comes down to a couple of scenarios:

- It is a member of the hard-coded Pathways that are to be skipped (SkipInstancechecker.buildStaticSkiplist)
- It's only parent TopLevelPathway is Disease (1643685)
    - In cases where there are multiple TopLevelPathways, the Reaction is still inferred, but the Disease (and its children) pathway inference is suppressed. 
