### PR TITLE
Feature/74 changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,9 @@ pipeline{
 		stage('Setup: Download Orthopairs files from S3 bucket'){
 			steps{
 				script{
+					def releaseVersion = utils.getReleaseVersion()
 					sh "mkdir -p orthopairs"
-					sh "aws s3 --no-progress cp --recursive ${env.S3_RELEASE_DIRECTORY_URL}/${currentRelease}/orthopairs/data/orthopairs/ ./orthopairs/"
+					sh "aws s3 --no-progress cp --recursive ${env.S3_RELEASE_DIRECTORY_URL}/${releaseVersion}/orthopairs/data/orthopairs/ ./orthopairs/"
 					sh "gunzip orthopairs/*"
 				}
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,10 +158,10 @@ pipeline{
 					def prevGraphQAFileName = "GraphQA_Summary_v${previousReleaseVersion}.csv"
 					def currentGraphQAFileName = "GraphQA_Summary_v${releaseVersion}.csv"
 					def s3PathPrevGraphQA = "${env.S3_RELEASE_DIRECTORY_URL}/${previousReleaseVersion}/orthoinference/reports/${prevGraphQAFileName}.gz"
-					
+					// Get previous release graph-qa output
 					sh "aws s3 cp ${s3PathPrevGraphQA} ."
 					sh "gunzip ${prevGraphQAFileName}.gz"
-					
+					// Email the graph-qa outputs from the current and previous releases
 					def emailSubject = "Orthoinference graph-qa for v${releaseVersion}"
 					def emailBody = "Hello,\n\nThis is an automated message from Jenkins regarding an update for v${releaseVersion}. The Orthoinference step has finished running. Attached to this email should be the summary report output by graph-qa for both v${releaseVersion} and v${previousReleaseVersion}. Please compare these and confirm if they look appropriate with the developer running Release. \n\nThanks!"
 					def emailAttachments = "graph-qa/reports/${currentGraphQAFileName}, ${prevGraphQAFileName}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,7 +177,7 @@ pipeline{
 			steps{
 				script{
 				    def releaseVersion = utils.getReleaseVersion()
-				    def dataFiles = ["orthoinferences", "report_ortho_inference_test_reactome_${releaseVersion}*.txt",]
+				    def dataFiles = ["orthoinferences", "report_ortho_inference_test_reactome_${releaseVersion}*.txt"]
 					// Additional log files from post-step QA need to be pulled in
 					def logFiles = ["graph-importer/logs/*", "graph-qa/logs/*", "graph-qa/reports/*"]
 					// This folder is utilized for post-step QA. Jenkins creates multiple temporary directories

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,12 +75,13 @@ pipeline{
 					sh "cp ${inferenceReportFilename} ${env.WEBSITE_FILES_UPDATE_ABS_PATH}/"
 					dir("${env.WEBSITE_FILES_UPDATE_ABS_PATH}"){
 						// Creates hard-link of sorted report_ortho_inference file, in website_files_update folder.
+						// This allows the generically named file to be committed to git so that we can track it over releases.
 						sh "ln -f ${inferenceReportFilename} report_ortho_inference.txt"
 					}
 				}
 			}
 		}
-		// This stage downloads the previous releases orthoinference files (eligible, inferred), and outputs line count differenes between them.
+		// This stage downloads the previous releases orthoinference files (eligible, inferred), and outputs line count differences between them.
 		stage('Post: Orthoinference file line counts') {
 		    steps{
 		        script{
@@ -89,6 +90,7 @@ pipeline{
 		            def orthoinferencesDir = "orthoinferences"
 		            def currentDir = pwd()
 		            
+			    // Create the 'orthoinferences' and 'previousReleaseVersion' directories
 		            sh "mkdir -p ${orthoinferencesDir} ${previousReleaseVersion}"
 		            sh "mv eligible* inferred* ${orthoinferencesDir}/"
 		            sh "aws s3 --recursive --no-progress cp s3://reactome/private/releases/${previousReleaseVersion}/orthoinference/data/orthoinferences/ ${previousReleaseVersion}/"

--- a/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -75,8 +75,8 @@ public class EventsInferrer
 		setDbAdaptors(dbAdaptor);
 
 		releaseVersion = props.getProperty("releaseNumber");
-		String pathToOrthopairs = props.getProperty("pathToOrthopairs");
-		String pathToSpeciesConfig = props.getProperty("pathToSpeciesConfig");
+		String pathToOrthopairs = props.getProperty("pathToOrthopairs", "orthopairs");
+		String pathToSpeciesConfig = props.getProperty("pathToSpeciesConfig", "src/main/resources/Species.json");
 		String dateOfRelease = props.getProperty("dateOfRelease");
 		int personId = Integer.valueOf(props.getProperty("personId"));
 		setReleaseDates(dateOfRelease);

--- a/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.gk.model.GKInstance;
 import static org.gk.model.ReactomeJavaConstants.*;
+
 import org.gk.persistence.MySQLAdaptor;
 import org.gk.schema.InvalidAttributeException;
 import org.gk.schema.SchemaClass;
@@ -51,6 +52,7 @@ public class EventsInferrer
 	private static List<GKInstance> manualHumanEvents = new ArrayList<>();
 	private static StableIdentifierGenerator stableIdentifierGenerator;
 	private static OrthologousPathwayDiagramGenerator orthologousPathwayDiagramGenerator;
+	private static final String INFERRED_EVIDENCE_TYPE_DISPLAY_NAME = "inferred by electronic annotation";
 
 	@SuppressWarnings("unchecked")
 	public static void inferEvents(Properties props, String species) throws Exception
@@ -165,16 +167,21 @@ public class EventsInferrer
 			// Check if the current Reaction already exists for this species, that it is a valid instance (passes some filters), and that it doesn't have a Disease attribute.
 			// Adds to manualHumanEvents array if it passes conditions. This code block allows you to re-run the code without re-inferring instances.
 			List<GKInstance> previouslyInferredInstances = new ArrayList<GKInstance>();
-			previouslyInferredInstances = checkIfPreviouslyInferred(reactionInst, orthologousEvent, previouslyInferredInstances);
-			previouslyInferredInstances = checkIfPreviouslyInferred(reactionInst, inferredFrom, previouslyInferredInstances);
+			previouslyInferredInstances.addAll(checkIfPreviouslyInferred(reactionInst, orthologousEvent, previouslyInferredInstances));
+			previouslyInferredInstances.addAll(checkIfPreviouslyInferred(reactionInst, inferredFrom, previouslyInferredInstances));
 			if (previouslyInferredInstances.size() > 0)
 			{
 				GKInstance prevInfInst = previouslyInferredInstances.get(0);
 				if (prevInfInst.getAttributeValue(disease) == null)
 				{
-					logger.info("Inferred RlE already exists, skipping inference");
-					manualEventToNonHumanSource.put(reactionInst, prevInfInst);
-					manualHumanEvents.add(reactionInst);
+					GKInstance evidenceTypeInst = (GKInstance) prevInfInst.getAttributeValue(evidenceType);
+					if (evidenceTypeInst != null && evidenceTypeInst.getDisplayName().contains(INFERRED_EVIDENCE_TYPE_DISPLAY_NAME)) {
+						ReactionInferrer.addAlreadyInferredEvents(reactionInst, prevInfInst);
+					} else {
+						logger.info("Inferred RlE already exists, skipping inference");
+						manualEventToNonHumanSource.put(reactionInst, prevInfInst);
+						manualHumanEvents.add(reactionInst);
+					}
 				} else {
 					logger.info("Disease reaction, skipping inference");
 				}
@@ -354,7 +361,7 @@ public class EventsInferrer
 		GKInstance evidenceTypeInst = new GKInstance(dbAdaptor.getSchema().getClassByName(EvidenceType));
 		evidenceTypeInst.setDbAdaptor(dbAdaptor);
 		evidenceTypeInst.addAttributeValue(created, instanceEditInst);
-		String evidenceTypeText = "inferred by electronic annotation";
+		String evidenceTypeText = INFERRED_EVIDENCE_TYPE_DISPLAY_NAME;
 		evidenceTypeInst.addAttributeValue(name, evidenceTypeText);
 		evidenceTypeInst.addAttributeValue(name, "IEA");
 		evidenceTypeInst.addAttributeValue(_displayName, evidenceTypeText);

--- a/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
+++ b/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
@@ -313,4 +313,9 @@ public class ReactionInferrer {
 		return inferredCount;
 	}
 
+	public static void addAlreadyInferredEvents(GKInstance reactionInst, GKInstance previouslyInferredReactionInst) {
+		inferredEvent.put(reactionInst, previouslyInferredReactionInst);
+		inferrableHumanEvents.add(reactionInst);
+
+	}
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,9 +2,9 @@
 <Configuration status="info">
 	<Appenders>
 <!-- Uncomment below block to get logging output to the console.-->
-<!--		<Console name="Console" target="SYSTEM_OUT">-->
+		<Console name="Console" target="SYSTEM_OUT">
 <!--			<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />-->
-<!--		</Console>-->
+		</Console>
 		<RollingFile name="LogFile" fileName="logs/OrthoInference-${date:MM-dd-yyyy_HH.mm.ss}.log" filePattern="logs/OrthoInference-%d{MM-dd-yyyy_HH.mm.ss}.log">
 			<PatternLayout>
 				<Pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info">
 	<Appenders>
-		<Console name="Console" target="SYSTEM_OUT">
-			<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
-		</Console>
+<!-- Uncomment below block to get logging output to the console.-->
+<!--		<Console name="Console" target="SYSTEM_OUT">-->
+<!--			<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />-->
+<!--		</Console>-->
 		<RollingFile name="LogFile" fileName="logs/OrthoInference-${date:MM-dd-yyyy_HH.mm.ss}.log" filePattern="logs/OrthoInference-%d{MM-dd-yyyy_HH.mm.ss}.log">
 			<PatternLayout>
 				<Pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info">
 	<Appenders>
-<!-- Uncomment below block to get logging output to the console.-->
 		<Console name="Console" target="SYSTEM_OUT">
-<!--			<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />-->
+			<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
 		</Console>
 		<RollingFile name="LogFile" fileName="logs/OrthoInference-${date:MM-dd-yyyy_HH.mm.ss}.log" filePattern="logs/OrthoInference-%d{MM-dd-yyyy_HH.mm.ss}.log">
 			<PatternLayout>
@@ -27,7 +26,8 @@
 			<AppenderRef ref="warningsLogFile"/>
 		</Logger>
 		<Root level="debug">
-			<AppenderRef ref="Console" level="debug"/>
+<!-- Uncomment below AppenderRef 'Console' block to turn on console logging -->
+<!--			<AppenderRef ref="Console" level="debug"/>-->
 			<AppenderRef ref="LogFile" level="info"/>
 		</Root>
 	</Loggers>


### PR DESCRIPTION
This orthoinference PR includes:

- Converted JF to use shared library
- New post-step functionality that outputs the line counts for the inferred/eligible files
- Log files are now pre-pended with the 4-letter species code (eg. mmus; Jenkins-specific action)
- Interruption-proofing of actual orthoinference code
- Default values added for some properties (filepaths)